### PR TITLE
set result of verify() functions to null

### DIFF
--- a/u2f-server/core.c
+++ b/u2f-server/core.c
@@ -751,6 +751,7 @@ u2fs_rc u2fs_registration_verify(u2fs_ctx_t * ctx, const char *response,
   registrationData = NULL;
   clientData = NULL;
   keyHandle = NULL;
+  *output = NULL;
 
   rc = parse_registration_response(response, &registrationData,
                                    &clientData);
@@ -1150,6 +1151,7 @@ u2fs_rc u2fs_authentication_verify(u2fs_ctx_t * ctx, const char *response,
   challenge = NULL;
   origin = NULL;
   signature = NULL;
+  *output = NULL;
 
   rc = parse_authentication_response(response, &signatureData,
                                      &clientData, &keyHandle);


### PR DESCRIPTION
calling u2fs_free_reg_res() after a failed call to u2fs_registration_verify() will crash unless the caller set the u2fs_reg_res_t to NULL first.  initially setting it to null inside the verify() function avoids this pitfall

same for u2fs_free_auth_res()