### PR TITLE
Make attestation cert available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 # http://www.gnu.org/s/libtool/manual/html_node/Updating-version-info.html
 AC_SUBST(LT_CURRENT, 0)
-AC_SUBST(LT_REVISION, 4)
+AC_SUBST(LT_REVISION, 5)
 AC_SUBST(LT_AGE, 0)
 
 AM_INIT_AUTOMAKE([gnits dist-xz no-dist-gzip std-options -Wall])

--- a/tests/core.c
+++ b/tests/core.c
@@ -219,6 +219,22 @@ END_TEST START_TEST(registration_verify_ok)
   p = u2fs_get_registration_publicKey(res);
   ck_assert_int_eq(memcmp(p, userkey_dat, U2FS_PUBLIC_KEY_LEN), 0);
 
+  ck_assert_str_eq(u2fs_get_registration_attestation(res),
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIICGzCCAQWgAwIBAgIEdaP2dTALBgkqhkiG9w0BAQswLjEsMCoGA1UEAxMjWXVi\n"
+  "aWNvIFUyRiBSb290IENBIFNlcmlhbCA0NTcyMDA2MzEwIBcNMTQwODAxMDAwMDAw\n"
+  "WhgPMjA1MDA5MDQwMDAwMDBaMCoxKDAmBgNVBAMMH1l1YmljbyBVMkYgRUUgU2Vy\n"
+  "aWFsIDE5NzM2Nzk3MzMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQZo35Damtp\n"
+  "l81YdmcbhEuXKAr7xDcQzAy5n3ftAAhtBbu8EeGU4ynfSgLonckqX6J2uXLBppTN\n"
+  "E3v2bt+Yf8MLoxIwEDAOBgorBgEEAYLECgECBAAwCwYJKoZIhvcNAQELA4IBAQG9\n"
+  "LbiNPgs0sQYOHAJcg+lMk+HCsiWRlYVnbT4I/5lnqU907vY17XYAORd432bU3Nnh\n"
+  "sbkvjz76kQJGXeNAF4DPANGGlz8JU+LNEVE2PWPGgEM0GXgB7mZN5Sinfy1AoOdO\n"
+  "+3c3bfdJQuXlUxHbo+nDpxxKpzq9gr++RbokF1+0JBkMbaA/qLYL4WdhY5NvaOyM\n"
+  "vYpO3sBxlzn6FcP67hlotGH1wU7qhCeh+uur7zDeAWVh7c4QtJOXHkLJQfV3Z7ZM\n"
+  "vhkIA6jZJAX99hisABU/SSa5DtgX7AfsHwa04h69AAAWDUzSk3HgOXbUd1FaSOPd\n"
+  "lVFkG2N2JllFHykyO3zO\n"
+  "-----END CERTIFICATE-----\n");
+
   u2fs_free_reg_res(res);
   u2fs_done(ctx);
   u2fs_global_done();

--- a/u2f-server/core.c
+++ b/u2f-server/core.c
@@ -293,12 +293,12 @@ const char *u2fs_get_registration_publicKey(u2fs_reg_res_t * result)
  * Returns: On success the pointer to the buffer containing the attestation
  * certificate is returned, and on errors NULL.
  */
-u2fs_X509_t *u2fs_get_registration_attestation(u2fs_reg_res_t * result)
+const void *u2fs_get_registration_attestation(u2fs_reg_res_t * result)
 {
   if (result == NULL)
     return NULL;
 
-  return result->attestation_certificate;
+  return (void*)result->attestation_certificate;
 }
 
 /**

--- a/u2f-server/core.c
+++ b/u2f-server/core.c
@@ -283,6 +283,25 @@ const char *u2fs_get_registration_publicKey(u2fs_reg_res_t * result)
 }
 
 /**
+ * u2fs_get_registration_attestation:
+ * @result: a registration result obtained from u2fs_registration_verify()
+ *
+ * Extract the X509 attestation certificate obtained during the U2F
+ * registration operation.  The memory is allocated by the library,
+ * and must not be deallocated by the caller.
+ *
+ * Returns: On success the pointer to the buffer containing the attestation
+ * certificate is returned, and on errors NULL.
+ */
+u2fs_X509_t *u2fs_get_registration_attestation(u2fs_reg_res_t * result)
+{
+  if (result == NULL)
+    return NULL;
+
+  return result->attestation_certificate;
+}
+
+/**
  * u2fs_get_authentication_result:
  * @result: an authentication result obtained from u2fs_authentication_verify()
  * @verified: output parameter for the authentication result

--- a/u2f-server/core.c
+++ b/u2f-server/core.c
@@ -248,7 +248,7 @@ u2fs_set_publicKey(u2fs_ctx_t * ctx, const unsigned char *publicKey)
  * @result: a registration result obtained from u2fs_registration_verify()
  *
  * Get the Base64 keyHandle obtained during the U2F registration
- * operation.  The memory is allocate by the library, and must not be
+ * operation.  The memory is allocated by the library, and must not be
  * deallocated by the caller.
  *
  * Returns: On success the pointer to the buffer containing the keyHandle

--- a/u2f-server/crypto.h
+++ b/u2f-server/crypto.h
@@ -63,5 +63,6 @@ u2fs_EC_KEY_t *dup_key(const u2fs_EC_KEY_t * key);
 u2fs_X509_t *dup_cert(const u2fs_X509_t * cert);
 
 u2fs_rc dump_user_key(const u2fs_EC_KEY_t * key, char **output);
+u2fs_rc dump_X509_cert(const u2fs_X509_t * cert, char **output);
 
 #endif

--- a/u2f-server/internal.h
+++ b/u2f-server/internal.h
@@ -49,6 +49,7 @@ extern int debug;
 struct u2fs_reg_res {
   char *keyHandle;
   char *publicKey;
+  char *attestation_certificate_PEM;
   u2fs_EC_KEY_t *user_public_key;
   u2fs_X509_t *attestation_certificate;
 };

--- a/u2f-server/openssl.c
+++ b/u2f-server/openssl.c
@@ -325,6 +325,20 @@ u2fs_rc dump_X509_cert(const u2fs_X509_t * cert, char **output)
   if (cert == NULL || output == NULL)
     return U2FS_MEMORY_ERROR;
 
+  BIO *bio = BIO_new(BIO_s_mem());
+
+  if(!PEM_write_bio_X509(bio, (X509 *)cert)) {
+    BIO_free(bio);
+    output = NULL;
+    return U2FS_CRYPTO_ERROR;
+  }
+
+  char* PEM_data;
+  int length = BIO_get_mem_data(bio, &PEM_data);
+  *output = malloc(length);
+  memcpy(*output, PEM_data, length);
+  BIO_free(bio);
+
   return U2FS_OK;
 
 }

--- a/u2f-server/openssl.c
+++ b/u2f-server/openssl.c
@@ -329,7 +329,7 @@ u2fs_rc dump_X509_cert(const u2fs_X509_t * cert, char **output)
 
   if(!PEM_write_bio_X509(bio, (X509 *)cert)) {
     BIO_free(bio);
-    output = NULL;
+    *output = NULL;
     return U2FS_CRYPTO_ERROR;
   }
 

--- a/u2f-server/openssl.c
+++ b/u2f-server/openssl.c
@@ -279,7 +279,7 @@ void free_sig(u2fs_ECDSA_t * sig)
 
 u2fs_rc dump_user_key(const u2fs_EC_KEY_t * key, char **output)
 {
-  //TODO add PEM
+  //TODO add PEM - current output is openssl octet string
 
   if (key == NULL || output == NULL)
     return U2FS_MEMORY_ERROR;
@@ -312,6 +312,18 @@ u2fs_rc dump_user_key(const u2fs_EC_KEY_t * key, char **output)
 
   EC_GROUP_free(ecg);
   ecg = NULL;
+
+  return U2FS_OK;
+
+}
+
+u2fs_rc dump_X509_cert(const u2fs_X509_t * cert, char **output)
+{
+  //input: openssl X509 certificate
+  //output: PEM-formatted char buffer
+
+  if (cert == NULL || output == NULL)
+    return U2FS_MEMORY_ERROR;
 
   return U2FS_OK;
 
@@ -383,7 +395,7 @@ END_TEST START_TEST(test_dup_key)
   ck_assert_int_eq(decode_user_key(userkey_dat, &key), U2FS_OK);
   key2 = dup_key(key);
   ck_assert(key2 != NULL);
-  //ck_assert(memcmp(key, key2, sizeof(key)));  
+  //ck_assert(memcmp(key, key2, sizeof(key)));
 
 }
 

--- a/u2f-server/u2f-server.h
+++ b/u2f-server/u2f-server.h
@@ -111,7 +111,7 @@ extern "C" {
 
   const char *u2fs_get_registration_keyHandle(u2fs_reg_res_t * result);
   const char *u2fs_get_registration_publicKey(u2fs_reg_res_t * result);
-  const void *u2fs_get_registration_attestation(u2fs_reg_res_t * result);
+  const char *u2fs_get_registration_attestation(u2fs_reg_res_t * result);
 
   void u2fs_free_reg_res(u2fs_reg_res_t * result);
 

--- a/u2f-server/u2f-server.h
+++ b/u2f-server/u2f-server.h
@@ -111,7 +111,7 @@ extern "C" {
 
   const char *u2fs_get_registration_keyHandle(u2fs_reg_res_t * result);
   const char *u2fs_get_registration_publicKey(u2fs_reg_res_t * result);
-  u2fs_X509_t *u2fs_get_registration_attestation(u2fs_reg_res_t * result);
+  const void *u2fs_get_registration_attestation(u2fs_reg_res_t * result);
 
   void u2fs_free_reg_res(u2fs_reg_res_t * result);
 

--- a/u2f-server/u2f-server.h
+++ b/u2f-server/u2f-server.h
@@ -111,6 +111,7 @@ extern "C" {
 
   const char *u2fs_get_registration_keyHandle(u2fs_reg_res_t * result);
   const char *u2fs_get_registration_publicKey(u2fs_reg_res_t * result);
+  u2fs_X509_t *u2fs_get_registration_attestation(u2fs_reg_res_t * result);
 
   void u2fs_free_reg_res(u2fs_reg_res_t * result);
 

--- a/u2f-server/u2f-server.map
+++ b/u2f-server/u2f-server.map
@@ -40,6 +40,7 @@ U2F_SERVER_0.0.0
     u2fs_get_registration_result;
     u2fs_get_registration_keyHandle;
     u2fs_get_registration_publicKey;
+    u2fs_get_registration_attestation;
     u2fs_global_done;
     u2fs_global_init;
     u2fs_init;


### PR DESCRIPTION
lets the calling application retrieve the attestation cert, same style as retrieving the keyhandle/publickey
