### PR TITLE
Janitorial patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: c
+os:
+  - linux
+  - osx
 compiler:
   - gcc
   - clang
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get remove -qq -y $REMOVE
-  - sudo apt-get autoremove -qq
-  - sudo apt-get install -qq -y gengetopt help2man $EXTRA
-env:
-  - EXTRA="libjson0-dev libssl-dev check"
 script: ./build-aux/travis
 matrix:
   include:
     - compiler: gcc
-      env: COVERAGE="--enable-coverage" EXTRA="libjson0-dev libssl-dev check lcov"
+      env: COVERAGE="--enable-coverage"

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+main() {
+  autoreconf --install
+}
+
+pushd "$DIR" &>/dev/null
+  main "$@"
+popd &>/dev/null

--- a/build-aux/travis
+++ b/build-aux/travis
@@ -1,12 +1,25 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -exv
+env | sort
 
-set -e
-set -x
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  sudo apt-get update -qq
+  sudo apt-get autoremove -qq
+  sudo apt-get install -qq -y gengetopt help2man libjson0-dev libssl-dev check lcov
+elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  brew update
+  brew install gengetopt help2man pkg-config json-c openssl check
+  export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
+else
+  echo "Unsupported OS: $TRAVIS_OS_NAME"
+  exit 1
+fi
 
-autoreconf -i
+./autogen.sh
 ./configure --disable-h2a $COVERAGE --enable-tests
 make check
-if [ "x$COVERAGE" != "x" ]; then
+
+if [[ ! -z "$COVERAGE" ]]; then
   gem install coveralls-lcov
   coveralls-lcov coverage/app3.info
 fi

--- a/src/u2f-server.c
+++ b/src/u2f-server.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 {
   int exit_code = EXIT_FAILURE;
   struct gengetopt_args_info args_info;
-  char buf[BUFSIZ];
+  char buf[8192];
   char *p;
   u2fs_ctx_t *ctx;
   u2fs_reg_res_t *reg_result;

--- a/u2f-server/Makefile.am
+++ b/u2f-server/Makefile.am
@@ -27,7 +27,7 @@
 
 AM_CFLAGS = $(WARN_CFLAGS)
 AM_CPPFLAGS = -I$(srcdir)/.. -I$(builddir)/..
-AM_CPPFLAGS += $(LIBJSON_CFLAGS) $(LIBSSL_CFLAGS)
+AM_CPPFLAGS += $(LIBJSON_CFLAGS) $(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS)
 
 lib_LTLIBRARIES = libu2f-server.la
 u2f_server_includedir = $(includedir)/u2f-server
@@ -43,7 +43,7 @@ libu2f_server_la_SOURCES += cencode.c cdecode.c b64/cencode.h b64/cdecode.h
 libu2f_server_la_SOURCES += crypto.h
 libu2f_server_la_SOURCES += openssl.c
 
-libu2f_server_la_LIBADD = $(HIDAPI_LIBS) $(LIBJSON_LIBS) $(LIBSSL_LIBS)
+libu2f_server_la_LIBADD = $(HIDAPI_LIBS) $(LIBJSON_LIBS) $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
 
 libu2f_server_la_LDFLAGS = -no-undefined \
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)


### PR DESCRIPTION
- Introduce autogen.sh (should be dropped into all of our autotool based projects)
- Add missing dependancies (spotted by @mouse07410)
- Build on OSX (travis).

Fix a bug (this might be worth a release) where the input buffer used in `u2f-server` on OSX was to small to read in the entire registration response (BUFSIZ strikes again).