### PR TITLE
Janitorial services.

### DIFF
--- a/BLURB
+++ b/BLURB
@@ -1,7 +1,0 @@
-Author: Yubico
-Basename: libu2f-server
-Homepage: https://developers.yubico.com/libu2f-server/
-License: BSD-2-Clause
-Name: libu2f-server
-Project: libu2f-server
-Summary: Yubico Universal 2nd Factor (U2F) Server C Library

--- a/README
+++ b/README
@@ -159,56 +159,42 @@ which will report either a successful or a failed authentication.
 For successful authentication the counter value and the user
 presence value will be printed as well.
 
-[[building]]
 Building
 --------
 
-This project uses 'autoconf', 'automake' and 'libtool' to achieve
-portability and ease of use.  If you downloaded a tarball, build it as
-follows.
+This project has a handful of Dependencies that must be satisfied prior to
+build -- consult `build-aux/travis` for insights if you run into issues.
 
+Autotools are required, this includes `autoconf`, `automake` and `libtool`,
+`check`  is only required for tests, and the library will build with out.
+
+Debian:
+-----------
+  # apt-get install check gengetopt gtk-doc-tools help2man libssl-dev libjson-c-dev
+-----------
+
+RHEL:
+-----------
+  # yum install check-devel gengetopt gtk-doc help2man openssl-devel json-c-devel
+-----------
+
+macOS:
+-----------
+  $ brew install check gengetopt gtk-doc help2man json-c openssl pkg-config
+  $ export PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig
+-----------
+
+Building from a release tarball:
 -----------
   $ ./configure --enable-gtk-doc --enable-tests
-  $ make check && sudo make install
+  $ make && make check
+  # make install
 -----------
 
-The JSON library is needed, see: +
-https://github.com/json-c/json-c/wiki +
-Debian:	+apt-get install libjson0-dev+ +
-
-You will also need OpenSSL: +
-https://www.openssl.org/ +
-Debian:	+apt-get install libssl-dev+ +
-
-In order to perform self tests with +make check+,
-the Check Framework should be installed. However this is not required
-to build the library. +
-http://check.sourceforge.net/ +
-Debian:	+apt-get install check+ +
-
-Building from Git
------------------
-
-You may check out the sources using Git with the following command:
-
+From source:
 -----------
-  $ git clone git://github.com/Yubico/libu2f-server.git
+  $ ./autogen.sh
+  $ ./configure --enable-gtk-doc --enable-tests
+  $ make && make check
+  # make install
 -----------
-
-This will create a directory 'libu2f-server'.  Enter the directory:
-
------------
-  $ cd libu2f-server
------------
-
-Autoconf, automake and libtool must be installed. Help2man is used to
-generate the manpages. Gengetopt is needed for command line parameter
-handling
-
-Generate the build system using:
-
------------
-  $ autoreconf --install
------------
-
-Then build as usual, see above under <<building,Building>>.

--- a/README
+++ b/README
@@ -170,24 +170,24 @@ Autotools are required, this includes `autoconf`, `automake` and `libtool`,
 
 Debian:
 -----------
-  # apt-get install check gengetopt gtk-doc-tools help2man libssl-dev libjson-c-dev
+  # apt-get install check gengetopt help2man libssl-dev libjson-c-dev
 -----------
 
 RHEL:
 -----------
-  # yum install check-devel gengetopt gtk-doc help2man openssl-devel json-c-devel
+  # yum install check-devel gengetopt help2man openssl-devel json-c-devel
 -----------
 
 macOS:
 -----------
-  $ brew install check gengetopt gtk-doc help2man json-c openssl pkg-config
+  $ brew install check gengetopt help2man json-c openssl pkg-config
   $ export PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig
 -----------
 
 Building from a release tarball:
 
 -----------
-  $ ./configure --enable-gtk-doc --enable-tests
+  $ ./configure --enable-tests
   $ make && make check
   # make install
 -----------
@@ -196,7 +196,7 @@ From source:
 
 -----------
   $ ./autogen.sh
-  $ ./configure --enable-gtk-doc --enable-tests
+  $ ./configure --enable-tests
   $ make && make check
   # make install
 -----------

--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 Yubico Universal 2nd Factor (U2F) Server C Library
 ==================================================
 
+image:https://img.shields.io/badge/License-BSD%202--Clause-orange.svg["License, link=https://opensource.org/licenses/BSD-2-Clause"]
 image:https://travis-ci.org/Yubico/libu2f-server.svg?branch=master["Build Status", link="https://travis-ci.org/Yubico/libu2f-server"]
 image:https://coveralls.io/repos/Yubico/libu2f-server/badge.svg?branch=master["Coverage Status", link="https://coveralls.io/r/Yubico/libu2f-server?branch=master"]
 image:https://scan.coverity.com/projects/5685/badge.svg["Coverity Status", link=https://scan.coverity.com/projects/5685]
@@ -24,14 +25,6 @@ current version of this library does not do so.  This is a known
 limitation, and we hope to address this as soon as possible.  Please
 be sure to understand the implication of this before using the
 library.
-
-License
--------
-
-The project is licensed under a BSD license. See the file COPYING for
-exact wording. For any copyright year range specified as YYYY-ZZZZ in
-this package note that the range specifies every single year in that
-closed interval.
 
 Versioning
 ----------

--- a/README
+++ b/README
@@ -185,6 +185,7 @@ macOS:
 -----------
 
 Building from a release tarball:
+
 -----------
   $ ./configure --enable-gtk-doc --enable-tests
   $ make && make check
@@ -192,6 +193,7 @@ Building from a release tarball:
 -----------
 
 From source:
+
 -----------
   $ ./autogen.sh
   $ ./configure --enable-gtk-doc --enable-tests

--- a/README
+++ b/README
@@ -225,14 +225,3 @@ Portability
 
 The main development platform is Debian GNU/Linux and it should be
 well supported.
-
-Namespaces
-----------
-
-......
-Project name: Yubico Universal 2nd Factor (U2F) Server C Library
-Short name: libu2f-server
-Symbol prefix: u2fs_
-Tool: u2f-server
-Pkg-config: u2f-server
-......

--- a/README
+++ b/README
@@ -219,9 +219,3 @@ Generate the build system using:
 -----------
 
 Then build as usual, see above under <<building,Building>>.
-
-Portability
------------
-
-The main development platform is Debian GNU/Linux and it should be
-well supported.

--- a/build-aux/travis
+++ b/build-aux/travis
@@ -16,7 +16,7 @@ else
 fi
 
 ./autogen.sh
-./configure --disable-h2a $COVERAGE --enable-tests
+./configure $COVERAGE --enable-tests
 make check
 
 if [[ ! -z "$COVERAGE" ]]; then

--- a/configure.ac
+++ b/configure.ac
@@ -43,8 +43,15 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT([win32-dll])
 
 GTK_DOC_CHECK(1.1)
-AM_MISSING_PROG(HELP2MAN, help2man, $missing_dir)
 AM_MISSING_PROG(HELP2ADOC, help2adoc, $missing_dir)
+AM_MISSING_PROG(HELP2MAN, help2man, $missing_dir)
+if ! which help2man >/dev/null ; then
+   AC_MSG_ERROR([help2man missing])
+fi
+if ! which gengetopt >/dev/null ; then
+   AC_MSG_ERROR([gengetopt missing])
+fi
+
 gl_LD_VERSION_SCRIPT
 
 PKG_CHECK_MODULES([LIBJSON], [json-c], [], [
@@ -70,7 +77,7 @@ AC_ARG_ENABLE([tests],
                               [enable_tests=no])
 AM_CONDITIONAL([ENABLE_TESTS],[test '!' "$enable_tests" = no])
 if test '!' "$enable_tests" = no; then
-  PKG_CHECK_MODULES([CHECK], [check], [], [AC_MSG_NOTICE(Check package not found `make check` won't work)])
+  PKG_CHECK_MODULES([CHECK], [check], [], [AC_MSG_ERROR(`check` not found)])
 fi
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,7 +28,7 @@
 AM_CFLAGS = $(WARN_CFLAGS)
 AM_CFLAGS += -DMAKE_CHECK
 AM_CPPFLAGS=-I$(srcdir)/.. -I$(builddir)/..
-AM_CPPFLAGS+=$(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS)
+AM_CPPFLAGS+=$(LIBSSL_CFLAGS) $(LIBCRYPTO_CFLAGS) $(LIBCHECK_CFLAGS)
 
 AM_LDFLAGS = -no-install
 
@@ -38,7 +38,7 @@ AM_LDFLAGS += --coverage
 endif
 
 LDADD = $(top_builddir)/u2f-server/libu2f-server.la
-LDADD += $(CHECK_LIBS) $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
+LDADD += $(CHECK_LIBS) $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS) $(LIBCHECK_LIBS)
 
 check_PROGRAMS = basic core openssl
 dist_check_SCRIPTS = u2f-server-test.sh


### PR DESCRIPTION
- Better build instructions, fixes #9 
- Fail on missing build requirements (help2man, gengetopt)
  - Ditto `check` under `--enable-tests`
- README cleanups, repo cleanup.
