### PR TITLE
lib, u2f-server: Introduce --x509cert.

### DIFF
--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -34,3 +34,4 @@ option "action" a "Action to take." values="register","authenticate" enum
 option "key-handle" k "A file containing a key-handle" string optional
 option "user-key" p "A file containing the public user-key" string optional
 option "debug" d "Print debug information to standard error" flag off
+option "x509cert" x "A file to write the registration attestation certificate to" string optional

--- a/src/u2f-server.c
+++ b/src/u2f-server.c
@@ -205,6 +205,20 @@ int main(int argc, char *argv[])
       exit(EXIT_FAILURE);
     }
 
+    if (args_info.x509cert_given) {
+      const char *pem = u2fs_get_registration_attestation(reg_result);
+      FILE *fp = fopen(args_info.x509cert_arg, "w");
+      if (fp == NULL) {
+        perror("fopen");
+        exit(EXIT_FAILURE);
+      }
+      size_t fwlen = fwrite(pem, 1, strlen(pem), fp);
+      if (fwlen != strlen(pem)) {
+        perror("fwrite");
+        exit(EXIT_FAILURE);
+      }
+      fclose(fp);
+    }
 
     if (args_info.key_handle_given) {
       FILE *fp;

--- a/u2f-server/openssl.c
+++ b/u2f-server/openssl.c
@@ -41,11 +41,12 @@
 void dumpCert(const u2fs_X509_t * certificate)
 {
   X509 *cert = (X509 *) certificate;
-  BIO *STDout = BIO_new_fp(stderr, BIO_NOCLOSE);
+  BIO *out = BIO_new_fp(stderr, BIO_NOCLOSE);
 
-  X509_print_ex(STDout, cert, 0, 0);
+  (void)X509_print_ex(out, cert, 0, 0);
+  (void)PEM_write_bio_X509(out, cert);
 
-  BIO_free(STDout);
+  BIO_free(out);
 }
 
 void crypto_init(void)


### PR DESCRIPTION
Dumps the attestation certificate to the provided file PEM formatted.
dumpCert() now emits it as well (under --debug).

Fixes #7