### PR TITLE
Correct a function declaration that does not match the definition.

### DIFF
--- a/u2f-server/core.c
+++ b/u2f-server/core.c
@@ -328,7 +328,7 @@ const char *u2fs_get_registration_attestation(u2fs_reg_res_t * result)
  * of the user (yubikey touched) during the authentication.
  */
 u2fs_rc u2fs_get_authentication_result(u2fs_auth_res_t * result,
-                                       int *verified,
+                                       u2fs_rc *verified,
                                        uint32_t * counter,
                                        uint8_t * user_presence)
 {


### PR DESCRIPTION
I was having trouble compiling parts of this library with arm-none-eabi-gcc 6.3.1.

I was getting:
```
core.c:330:9: error: conflicting types for 'u2fs_get_authentication_result'
```

Changing the type makes the compiler happy.