### PR TITLE
Do not use (de)initialization functions which are deprecated in openssl-1.1.0

### DIFF
--- a/u2f-server/openssl.c
+++ b/u2f-server/openssl.c
@@ -51,13 +51,19 @@ void dumpCert(const u2fs_X509_t * certificate)
 
 void crypto_init(void)
 {
-  SSL_load_error_strings();
+  /* Crypto init functions are deprecated in openssl-1.1.0 */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+   SSL_load_error_strings();
+#endif
 }
 
 void crypto_release(void)
 {
+  /* Crypto deinit functions are deprecated in openssl-1.1.0. */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   RAND_cleanup();
   ERR_free_strings();
+#endif
 }
 
 u2fs_rc set_random_bytes(char *data, size_t len)


### PR DESCRIPTION
These functions (among others) are deprecated in openssl-1.1.0:
SSL_load_error_strings, ERR_free_strings, RAND_cleanup.  They are not available
in openssl-1.1.0.g unless OPENSSL_API_COMPAT is set to a value lower than
0x10100000L during compilation.