### PR TITLE
Null terminating with len from fread could lead to one byte stack overwrite

### DIFF
--- a/src/u2f-server.c
+++ b/src/u2f-server.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
       }
 
-      len = fread(buf, sizeof(char), BUFSIZ, fp);
+      len = fread(buf, sizeof(char), sizeof(buf) - 1, fp);
       buf[len] = '\0';
       if (len == 0 && !feof(stdin)
           && ferror(stdin)) {
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
       }
 
-      len = fread(buf, sizeof(char), BUFSIZ, fp);
+      len = fread(buf, sizeof(char), sizeof(buf) - 1, fp);
       buf[len] = '\0';
       if (len == 0 && !feof(stdin)
           && ferror(stdin)) {
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
     goto done;
   }
   printf("%s\n", p);
-  len = fread(buf, 1, sizeof(buf), stdin);
+  len = fread(buf, 1, sizeof(buf) - 1, stdin);
   buf[len] = '\0';
   if (len == 0 && !feof(stdin)
       && ferror(stdin)) {


### PR DESCRIPTION
```
libu2f-server$ ragg2 -P 8192 |./src/u2f-server -a register -o https://www.foo.com -i lol -k README -p ./README
{ "challenge": "BIjQ54sAqbc6j5lCtqBFaf5SDuCfe1U9iN8joLGyhd0", "version": "U2F_V2", "appId": "lol" }
u2f-server.c:192:3: runtime error: index 8192 out of bounds for type 'char [8192]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior u2f-server.c:192:3 in 
=================================================================
==12559==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffed84e0490 at pc 0x000000528f5d bp 0x7ffed84de330 sp 0x7ffed84de328
```